### PR TITLE
fix PKESKv6 PQC encryption case

### DIFF
--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -1357,14 +1357,17 @@ pgp_pk_sesskey_t::write_material(const pgp_encrypted_material_t &material)
         FALLTHROUGH_STATEMENT;
     case PGP_PKA_KYBER768_BP256:
         FALLTHROUGH_STATEMENT;
-    case PGP_PKA_KYBER1024_BP384:
+    case PGP_PKA_KYBER1024_BP384: {
         pktbody.add(material.kyber_ecdh.composite_ciphertext);
-        pktbody.add_byte(static_cast<uint8_t>(material.kyber_ecdh.wrapped_sesskey.size()) + 1);
+        uint8_t opt_salg_length = (version == PGP_PKSK_V3) ? 1 : 0;
+        pktbody.add_byte(static_cast<uint8_t>(material.kyber_ecdh.wrapped_sesskey.size()) +
+                         opt_salg_length);
         if (version == PGP_PKSK_V3) {
             pktbody.add_byte(salg); /* added as plaintext */
         }
         pktbody.add(material.kyber_ecdh.wrapped_sesskey);
         break;
+    }
 #endif
     default:
         RNP_LOG("Unknown pk alg: %d", (int) alg);


### PR DESCRIPTION
Fixes #63

CLI Tests still have an error but I believe that's unrelated:

```
285: ERROR: test_zzz_encryption_and_signing_pqc (__main__.Encryption)
285: ----------------------------------------------------------------------
285: Traceback (most recent call last):
285:   File "/home/jroth/PQC_TB/rnp-dev/src/tests/cli_tests.py", line 4501, in test_zzz_encryption_and_signing_pqc
285:     signerpws = [passwds[i]]
285: IndexError: list index out of range
285: 
```

@falko-strenzke Should I still implement a unit test for PQC encryption (that would've caught this), or is it enough to have the CLI test now?